### PR TITLE
Update __init__.py

### DIFF
--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -2,6 +2,18 @@
 
 __version__ = "0.13.1"
 
+# Select compatible event loop for Tornado
+# Default value on Windows changed with python 3.8
+
+import asyncio
+import sys
+
+if sys.platform == "win32" and sys.version_info.minor >= 8:
+        asyncio.set_event_loop_policy(
+            asyncio.WindowsSelectorEventLoopPolicy()
+        )
+
+
 
 # We connect this function to the step after the builder is initialized
 def setup(app):


### PR DESCRIPTION
To enable running of jupyer-book on windows with python >= 3.8 the event-loop needs to be changed.

With this change I'm able to build my book (https://github.com/RubendeBruin/DAVE-book) on windows 10 using python 3.9 (other python versions not tested)